### PR TITLE
Don't read FILE in binary mode

### DIFF
--- a/sample_stream/__main__.py
+++ b/sample_stream/__main__.py
@@ -21,7 +21,7 @@ def main():
     parser.add_argument(
         "file",
         nargs="?",
-        type=argparse.FileType("rb"),
+        type=argparse.FileType("r"),
         default=stdin,
         help="File",
         metavar="FILE",


### PR DESCRIPTION
## Description

Hi Jeroen,

Have been reading your book and thought I'd give `sample` a try. 

I found that it failed silently when trying to read plain text via the `FILE` argument. Given plain text is the lingua franca, I assumed the `rb` was a bug. This PR simply fixes that.

I also thought the code to read lines can be tidied up a bit eg here: https://github.com/jeroenjanssens/sample/compare/main...hardingnj:sample:line_read

Finally,  it was slightly harder to debug as the code is catching all errors silently. 
I think it's probably important to error informatively if the user attempts to sample a `png` for example. Also, I think the bare `except` may interact in a non obvious way with `KeyboardInterrupt` etc.
I've got a branch that does this here: https://github.com/jeroenjanssens/sample/compare/main...hardingnj:sample:errorhandling

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/jeroenjanssens/sample-stream/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/jeroenjanssens/sample-stream/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
